### PR TITLE
Quick but important fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ WiiUDownloader
 WiiUDownloader.exe
 src/wiiudownloader.c
 src/Resources.c
+.DS_Store

--- a/src/GameList.cpp
+++ b/src/GameList.cpp
@@ -145,10 +145,14 @@ void GameList::search_entry_changed() {
 }
 
 void GameList::on_decrypt_selected(Gtk::ToggleButton *button) {
-    decryptContents = !decryptContents;
+    // decryptContents = !decryptContents; Bug Fix Attempt
     if(button->get_active())
+    {
+        decryptContents = true;
         deleteEncryptedContentsButton->set_sensitive(TRUE);
+    }
     else {
+        decryptContents = false;
         deleteEncryptedContentsButton->set_sensitive(FALSE);
         deleteEncryptedContentsButton->set_active(FALSE);
         deleteEncryptedContents = false;
@@ -156,7 +160,16 @@ void GameList::on_decrypt_selected(Gtk::ToggleButton *button) {
 }
 
 void GameList::on_delete_encrypted_selected(Gtk::ToggleButton *button) {
-    deleteEncryptedContents = !deleteEncryptedContents;
+    // deleteEncryptedContents = !deleteEncryptedContents; Bug Fix Attempt 2
+    // I think this way is just better because it ensures consistency no matter what the variable
+    // was previously set to.
+    if(button->get_active())
+    {
+        deleteEncryptedContents = true;
+    }
+    else {
+        deleteEncryptedContents = false;
+    }
 }
 
 void GameList::on_download_queue(GdkEventButton *ev) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -92,9 +92,20 @@ char *show_folder_select_dialog() {
     return outPath;
 }
 
+bool isThisDecryptedFile(const char *path) {
+    if (std::string(path).find("code") != std::string::npos ||
+        std::string(path).find("content") != std::string::npos ||
+        std::string(path).find("meta") != std::string::npos) {
+        return true;
+    }
+    return false;
+}
+
 void removeFiles(const char *path) {
-    for(const auto & entry : std::filesystem::directory_iterator(path)) {
-        if(entry.is_regular_file()) {
+    for (const auto &entry : std::filesystem::directory_iterator(path)) {
+        if (entry.is_directory()) {
+            removeFiles(entry.path().c_str());
+        } else if (entry.is_regular_file() && !isThisDecryptedFile(entry.path().c_str())) {
             std::filesystem::remove(entry.path());
         }
     }


### PR DESCRIPTION
This pull fixes two bugs I've had on my Mac;

1) Delete encrypted contents after decryption simply deleted the entire folder.

2) Sometimes the decrypt checkbox was checked but didn't result in automatic decryption after the files were downloaded

I've fixed both of these issues by changing how the checkboxes change variables and then changing the removeFiles method to work on MacOS aswell. Turns out entry.is_regular_file() recognises symbolic links as non regular files while folders are recognised as regular files on MacOS, resulting in everything being deleted.

Please keep in mind that this is my first time writing C++ code 😄