### PR TITLE
Fix `cdecrypt` failing on some games

### DIFF
--- a/src/cdecrypt/cdecrypt.c
+++ b/src/cdecrypt/cdecrypt.c
@@ -581,7 +581,8 @@ int cdecrypt(int argc, char **argv, bool showProgressDialog) {
                     fprintf(stderr, "ERROR: Could not open: '%s'\n", str);
                     goto out;
                 }
-                if ((getbe16(&fe[i].Flags) & 0x440)) {
+                uint16_t tmd_flags = tmd->Contents[getbe16(&fe[i].ContentID)].Type;
+                if ((getbe16(&tmd_flags) & 0x02)) {
                     if (!extract_file_hash(src, 0, cnt_offset, getbe32(&fe[i].FileLength), path, getbe16(&fe[i].ContentID)))
                         goto out;
                 } else {


### PR DESCRIPTION
This should fix two games that currently fail to decrypt. Verified fixes:
- [x] Assassin's Creed III
- [X] Darts Up

Explanation:
> cdecrypt reads some field it calls `Flags` that comes from (some file? c confuses me) to know whether the file is "hashed", while JNUSLib reads the `Content` entry in the TMD to find this out. I guess in most games, those agree, but in the two `cdecrypt` has an issue with it, they don't match up.