### PR TITLE
Fix file corruption when pausing download for >30s

### DIFF
--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -251,6 +251,8 @@ static int downloadFile(const char *download_url, const char *output_path, struc
     CURLcode curlCode;
     int retryCount = 0;
     do {
+        // Reset file position to start in case we have a partially-written file
+        fseek(file, 0, SEEK_SET);
         curlCode = curl_easy_perform(handle);
         if ((curlCode == CURLE_OK) || cancelled || queueCancelled)
             break;


### PR DESCRIPTION
I know you said you're already working on the Rust port, but this should help in the meantime. This PR simply resets the file position to the start of the file before activating curl, which should prevent it from appending a correctly-downloaded file to a partial download.

I've tested it by starting a download of "Darts Up (US)," waiting until the status box says it's downloading `00000016.app`, then pausing it and walking away for a minute. When resuming, it appears to stutter for a second, and then restart the file download from the beginning (as it did before,) but with this change, it doesn't corrupt the file when it does this.