### PR TITLE
[TESTING REQUIRED] Make WiiUDownloader remember the last selected path.

### DIFF
--- a/cmd/WiiUDownloader/config.go
+++ b/cmd/WiiUDownloader/config.go
@@ -14,11 +14,12 @@ import (
 )
 
 type Config struct {
-	DarkMode                bool  `koanf:"darkMode"`
-	DecryptContents         bool  `koanf:"decryptContents"`
-	DeleteEncryptedContents bool  `koanf:"deleteEncryptedContents"`
-	SelectedRegion          uint8 `koanf:"selectedRegion"`
-	DidInitialSetup         bool  `koanf:"didInitialSetup"`
+	DarkMode                bool   `koanf:"darkMode"`
+	DecryptContents         bool   `koanf:"decryptContents"`
+	DeleteEncryptedContents bool   `koanf:"deleteEncryptedContents"`
+	SelectedRegion          uint8  `koanf:"selectedRegion"`
+	DidInitialSetup         bool   `koanf:"didInitialSetup"`
+	LastSelectedPath        string `koanf:"lastSelectedPath"`
 	saveConfigCallback      func()
 	saveMutex               *sync.Mutex
 }
@@ -40,6 +41,7 @@ func getDefaultConfig() *Config {
 		DeleteEncryptedContents: false,
 		SelectedRegion:          wiiudownloader.MCP_REGION_EUROPE | wiiudownloader.MCP_REGION_USA | wiiudownloader.MCP_REGION_JAPAN,
 		DidInitialSetup:         false,
+		LastSelectedPath:        "",
 		saveConfigCallback:      nil,
 		saveMutex:               &sync.Mutex{},
 	}

--- a/cmd/WiiUDownloader/mainwindow.go
+++ b/cmd/WiiUDownloader/mainwindow.go
@@ -423,13 +423,24 @@ func (mw *MainWindow) ShowAll() {
 		if err != nil {
 			return
 		}
-		selectedPath, err := dialog.Directory().Title("Select a path to save the games to").Browse()
+		dialog := dialog.Directory().Title("Select a path to save the games to")
+		config, err := loadConfig()
+		if err != nil {
+			return
+		}
+		if config.LastSelectedPath != "" {
+			dialog.SetStartDir(config.LastSelectedPath) // no need to check validity, startDir only works if it is a valid existing directory, else works as if not set
+		}
+		selectedPath, err := dialog.Browse()
 		if err != nil {
 			glib.IdleAdd(func() {
 				mw.progressWindow.Window.Hide()
 			})
 			return
 		}
+		config.LastSelectedPath = selectedPath
+		_ = config.Save() // ignore error on saving new path
+
 		mw.progressWindow.Window.ShowAll()
 
 		go func() {


### PR DESCRIPTION
Most people download all their stuff into the same folder. So I decided to make the program remember the last selected path in the config and open the file selector dialog there since it is very likely the user will just want to go there anyway.

[TESTING REQUIRED] Please test on things that are not windows if you love your users and your sanity.

I did also notice that loadConfig returns an err but actually never does. Maybe make it truly infallible? atm you just panic with an error at every point. I did not change anything about that, thats your Constriction Site.

Regards Pizza