### PR TITLE
Added Download Path to Config Window

### DIFF
--- a/cmd/WiiUDownloader/utils.go
+++ b/cmd/WiiUDownloader/utils.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"os"
 	"strings"
 
 	"github.com/gotk3/gotk3/gtk"
@@ -46,4 +47,14 @@ func setDarkTheme(darkMode bool) {
 		log.Println(err.Error())
 	}
 	gSettings.SetProperty("gtk-application-prefer-dark-theme", darkMode)
+}
+
+func isValidPath(path string) bool {
+	if path == "" {
+		return false
+	}
+	if pathInfo, err := os.Stat(path); os.IsNotExist(err) || !pathInfo.IsDir() {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
The download path is now configurable via the Config window including a Browse button and validation.
The dialog to select a download path will be shown only if a path was not set already or the existing path is invalid, so no more choosing the same path each time.
Also, I fixed the Config window not loading correctly (empty) after closing it once and opening again.

![updated-config-with-path](https://github.com/user-attachments/assets/b7a8ea59-1715-4973-af43-1ed25e6b3a97)
