### PR TITLE
Keep Undownloaded Titles In Queue

### DIFF
--- a/cmd/WiiUDownloader/mainwindow.go
+++ b/cmd/WiiUDownloader/mainwindow.go
@@ -689,7 +689,6 @@ func (mw *MainWindow) onDownloadQueueClicked(selectedPath string) error {
 		}
 	})
 
-	mw.queuePane.Clear()
 	glib.IdleAdd(func() {
 		mw.progressWindow.Window.Hide()
 	})

--- a/cmd/WiiUDownloader/queuePane.go
+++ b/cmd/WiiUDownloader/queuePane.go
@@ -83,6 +83,8 @@ func NewQueuePane() (*QueuePane, error) {
 	if err != nil {
 		return nil, err
 	}
+	removeFromQueueButton.SetSizeRequest(-1, 42)
+
 	removeFromQueueButton.Connect("clicked", func() {
 		selection, err := titleTreeView.GetSelection()
 		if err != nil {


### PR DESCRIPTION
When pressing "Download queue" the current queue will be copied and downloaded, any title added to the download queue afterwards will now remain in the queue after the copied queue downloads have been finished and cleared from the queue (instead of being cleated with the rest, so you can press Download Queue again and download the remaining titles.
Also, made the "Remove from Queue" button the same height as the "Download queue" beside it.

![image](https://github.com/user-attachments/assets/ca2bf323-3121-44a8-9c5f-0a6fe7f627b9)

P.S.
Do you prefer to change "Remove from Queue" to "Remove from queue"
or change "Download queue" to "Download Queue"? :)