### PR TITLE
Support macOS Big Sur (11.0) in releases

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,13 +7,16 @@ on:
 permissions:
   contents: write
 
+env:
+  MACOSX_DEPLOYMENT_TARGET: "11.0"
+
 jobs:
   build:
     name: Build (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-15-intel, macos-15]
+        os: [macos-15-intel, macos-14]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v6
@@ -52,7 +55,7 @@ jobs:
 
   release:
     name: Release Universal Binary
-    runs-on: macos-15
+    runs-on: macos-14
     needs: build
     steps:
       - name: Check out repository code
@@ -69,7 +72,7 @@ jobs:
       - name: Download ARM Artifact
         uses: actions/download-artifact@v7
         with:
-          name: WiiUDownloader-App-macos-15
+          name: WiiUDownloader-App-macos-14
           path: arm_dist
       - name: Merge Universal Binary
         run: |

--- a/data/Info.plist
+++ b/data/Info.plist
@@ -25,6 +25,6 @@
     <key>NSHumanReadableCopyright</key>
     <string>Copyright 2022-2026 Xpl0itU, GNU General Public License Version 3.</string>
     <key>LSMinimumSystemVersion</key>
-    <string>15.0</string>
+    <string>11.0</string>
 </dict>
 </plist>

--- a/data/create_bundle.py
+++ b/data/create_bundle.py
@@ -8,6 +8,9 @@ import re
 import glob
 
 
+MIN_MACOS_VERSION = os.environ.get("MACOSX_DEPLOYMENT_TARGET", "11.0")
+
+
 def run(cmd):
     print(f"$ {cmd}")
     result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
@@ -15,6 +18,18 @@ def run(cmd):
         print(f"STDOUT: {result.stdout}")
         print(f"STDERR: {result.stderr}")
     return result
+
+
+def set_minimum_macos_version(path):
+    parts = MIN_MACOS_VERSION.split(".")
+    minos = ".".join((parts + ["0", "0"])[:2])
+    tmp_path = f"{path}.vtool.tmp"
+    result = run(
+        f'vtool -set-build-version macos {minos} {minos} -replace '
+        f'-output "{tmp_path}" "{path}" && mv "{tmp_path}" "{path}"'
+    )
+    if result.returncode != 0:
+        print(f"Warning: could not set minimum macOS version for {path}")
 
 
 def get_deps(path):
@@ -79,7 +94,11 @@ else:
     if not executable_path:
         try:
             build_dir = os.path.join("cmd", "WiiUDownloader")
-            subprocess.check_call(["go", "build", "-o", "main"], cwd=build_dir)
+            build_env = os.environ.copy()
+            build_env.setdefault("MACOSX_DEPLOYMENT_TARGET", MIN_MACOS_VERSION)
+            subprocess.check_call(
+                ["go", "build", "-o", "main"], cwd=build_dir, env=build_env
+            )
             executable_path = os.path.join(build_dir, "main")
         except subprocess.CalledProcessError as e:
             print(f"Error building executable: {e}")
@@ -213,6 +232,7 @@ for root, dirs, files in os.walk(macos_path):
                     new_path = f"@rpath/{os.path.basename(old_path)}"
                     run(f'install_name_tool -change "{old_path}" "{new_path}" "{p}"')
 
+            set_minimum_macos_version(p)
             run(f'codesign --force --sign - "{p}"')
 
 # 4. Resources


### PR DESCRIPTION
## Summary
- Lower `LSMinimumSystemVersion` from 15.0 to 11.0 so the app can launch on macOS Big Sur
- Set `MACOSX_DEPLOYMENT_TARGET=11.0` in CI and build the ARM slice on `macos-14`
- Stamp bundled GTK dylibs with minimum macOS 11.0 via `vtool` in `create_bundle.py` (important for Intel builds from `macos-15-intel`)
## Context
Current releases declare macOS 15+ and are built on macOS 15 runners, which blocks older macOS versions before the app starts. No application Go code changes were required — only packaging and CI.
Note: GitHub Actions no longer offers macOS 11 runners, so CI builds are cross-targeted with `MACOSX_DEPLOYMENT_TARGET`. A native Intel Big Sur build was also tested successfully outside CI.
## Test plan
- [ ] CI macOS workflow passes on tag push
- [ ] App launches on macOS Big Sur (Intel) — verified with a native/local bundled build
- [ ] Universal DMG still merges Intel + ARM artifacts correctly